### PR TITLE
bugfix: Check if mutable reference to `pending_notification` is `None`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -421,7 +421,7 @@ dependencies = [
 
 [[package]]
 name = "mpris-notifier"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "home",
  "image",

--- a/src/signal_handler.rs
+++ b/src/signal_handler.rs
@@ -122,8 +122,12 @@ impl SignalHandler {
                 self.pending_notification = Some(Notification::new(&sender, metadata, None));
             } else {
                 self.pending_notification = None;
-                return Ok(());
             }
+        }
+
+        //  We can't notify if the pending notification is still empty 
+        if self.pending_notification.as_mut().is_none() {
+            return Ok(());
         }
         let pending = self.pending_notification.as_mut().unwrap();
 


### PR DESCRIPTION
This is a small change intended to fix #3 - please feel free to critique and/or modify this PR as needed!

Similar to the `change` and `metadata` checks in `SignalHandler`, it adds an early return in the event that the mutable reference of `self.pending_notification` is `None`.

I'm not certain, but my suspicion is that the per-sender metadata caching may have something to do with the problem. I think the issue might be triggered when a single sender is responsible for sending property changes for multiple media player states (as is the case with Chromium, for instance, when tabs for a video site and a music service are both open).

These changes might not fully address the root cause, but after testing both dev and release builds locally, the panic described in #3 no longer occurs and I haven't noticed any regressions so far.