### PR TITLE
Call commands in `SignalHandler::handle_pending`

### DIFF
--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -51,6 +51,13 @@ pub struct Configuration {
     ///
     /// Default: [DEFAULT_ALBUM_ART_DEADLINE]
     pub album_art_deadline: u32,
+
+    /// A list of commands to be called on each notification. Each command
+    /// should be given as a sequence, the first item being the program and
+    /// following items being arguments.
+    ///
+    /// Default: [DEFAULT_COMMANDS]
+    pub commands: Vec<Vec<String>>,
 }
 
 const DEFAULT_SUBJECT_FORMAT: &str = "{track}";
@@ -58,6 +65,7 @@ const DEFAULT_BODY_FORMAT: &str = "{album} - {artist}";
 const DEFAULT_JOIN_STRING: &str = ", ";
 const DEFAULT_ENABLE_ALBUM_ART: bool = true;
 const DEFAULT_ALBUM_ART_DEADLINE: u32 = 1000;
+const DEFAULT_COMMANDS: Vec<Vec<String>> = vec![];
 
 impl Default for Configuration {
     fn default() -> Self {
@@ -67,6 +75,7 @@ impl Default for Configuration {
             join_string: DEFAULT_JOIN_STRING.to_string(),
             enable_album_art: DEFAULT_ENABLE_ALBUM_ART,
             album_art_deadline: DEFAULT_ALBUM_ART_DEADLINE,
+            commands: DEFAULT_COMMANDS,
         }
     }
 }
@@ -128,13 +137,22 @@ mod tests {
                           body_format = "{album}\n{artist}"
                           join_string = ' ⬥ '
                           enable_album_art = true
-                          album_art_deadline = 1500"#;
+                          album_art_deadline = 1500
+                          commands = [['pkill', '-RTMIN+2', 'waybar'], ['~/script.sh']]"#;
         let expected = Configuration {
             subject_format: "{track}".to_string(),
             body_format: "{album}\n{artist}".to_string(),
             join_string: " ⬥ ".to_string(),
             enable_album_art: true,
             album_art_deadline: 1500,
+            commands: vec![
+                vec![
+                    "pkill".to_string(),
+                    "-RTMIN+2".to_string(),
+                    "waybar".to_string(),
+                ],
+                vec!["~/script.sh".to_string()],
+            ],
         };
         fs::create_dir_all(&*TEST_TEMP_DIR).expect("test setup failed");
         fs::write(&conf_path, conf_data).expect("test setup failed");

--- a/src/signal_handler.rs
+++ b/src/signal_handler.rs
@@ -37,7 +37,7 @@ pub struct SignalHandler {
     // Notification that will be sent after [NOTIFICATION_DELAY] passes.
     pending_notification: Option<Notification>,
 
-    // Commands that will be called on MPRIS DBUS signals.
+    // Commands that will be called after [NOTIFICATION_DELAY] pasees.
     pending_commands: Vec<Command>,
 }
 
@@ -61,19 +61,20 @@ impl SignalHandler {
             if delta > NOTIFICATION_DELAY {
                 self.notifier
                     .send_notification(self.pending_notification.take().unwrap(), dbus)?;
-            }
-        }
 
-        for command in self.pending_commands.iter_mut() {
-            match command.output() {
-                Ok(_) => (),
-                Err(err) => {
-                    log::warn!("Command failed: {}", err);
+                for command in self.pending_commands.iter_mut() {
+                    match command.output() {
+                        Ok(_) => (),
+                        Err(err) => {
+                            log::warn!("Command failed: {}", err);
+                        }
+                    }
                 }
+
+                self.pending_commands.clear();
             }
         }
 
-        self.pending_commands.clear();
         Ok(())
     }
 

--- a/src/signal_handler.rs
+++ b/src/signal_handler.rs
@@ -75,6 +75,11 @@ impl SignalHandler {
             .clone();
         let change = MprisPropertiesChange::try_from(signal).ok();
 
+        // Signals we don't care about are ignored
+        if change.is_none() {
+            return Ok(());
+        }
+
         // Call commands for all signals, so that external programs are called
         // on pause and play.
         for command_args in self.configuration.commands.iter() {
@@ -103,10 +108,6 @@ impl SignalHandler {
             }
         }
 
-        // Signals we don't care about are ignored
-        if change.is_none() {
-            return Ok(());
-        }
         let change = change.unwrap();
 
         // Handle metadata property changes.

--- a/src/signal_handler.rs
+++ b/src/signal_handler.rs
@@ -37,7 +37,7 @@ pub struct SignalHandler {
     // Notification that will be sent after [NOTIFICATION_DELAY] passes.
     pending_notification: Option<Notification>,
 
-    // Commands that will be called after [NOTIFICATION_DELAY] passes.
+    // Commands that will be called on MPRIS DBUS signals.
     pending_commands: Vec<Command>,
 }
 


### PR DESCRIPTION
Calls commands in a new `SignalHandler::pending_commands` `Vec<Command>` from within the `SignalHandler::handle_pending` function.