### PR TITLE
Add support for setting urgency and category hints

### DIFF
--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -63,6 +63,13 @@ pub struct Configuration {
     ///
     /// Default: [DEFAULT_URGENCY]
     pub urgency: u8,
+
+    /// The category (type) of the notification.
+    /// See https://specifications.freedesktop.org/notification-spec/latest/ar01s06.html
+    /// for standard categories
+    ///
+    /// Default: [DEFAULT_CATEGORY]
+    pub category: String,
 }
 
 const DEFAULT_SUBJECT_FORMAT: &str = "{track}";
@@ -72,6 +79,7 @@ const DEFAULT_ENABLE_ALBUM_ART: bool = true;
 const DEFAULT_ALBUM_ART_DEADLINE: u32 = 1000;
 const DEFAULT_COMMANDS: Option<Vec<Vec<String>>> = None;
 const DEFAULT_URGENCY: u8 = 1; // Normal urgency
+const DEFAULT_CATEGORY: &str = "mpris.player_status";
 
 impl Default for Configuration {
     fn default() -> Self {
@@ -83,6 +91,7 @@ impl Default for Configuration {
             album_art_deadline: DEFAULT_ALBUM_ART_DEADLINE,
             commands: DEFAULT_COMMANDS,
             urgency: DEFAULT_URGENCY,
+            category: DEFAULT_CATEGORY.to_string(),
         }
     }
 }
@@ -146,6 +155,7 @@ mod tests {
                           enable_album_art = true
                           album_art_deadline = 1500
                           urgency = 0
+                          category = 'mpris.changed'
                           commands = [['pkill', '-RTMIN+2', 'waybar'], ['~/script.sh']]"#;
         let expected = Configuration {
             subject_format: "{track}".to_string(),
@@ -162,6 +172,7 @@ mod tests {
                 vec!["~/script.sh".to_string()],
             ]),
             urgency: 0,
+            category: "mpris.changed".to_string(),
         };
         fs::create_dir_all(&*TEST_TEMP_DIR).expect("test setup failed");
         fs::write(&conf_path, conf_data).expect("test setup failed");

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -58,6 +58,11 @@ pub struct Configuration {
     ///
     /// Default: [DEFAULT_COMMANDS]
     pub commands: Option<Vec<Vec<String>>>,
+
+    /// The urgency of the notification: 0 (low), 1 (normal), or 2 (critical).
+    ///
+    /// Default: [DEFAULT_URGENCY]
+    pub urgency: u8,
 }
 
 const DEFAULT_SUBJECT_FORMAT: &str = "{track}";
@@ -66,6 +71,7 @@ const DEFAULT_JOIN_STRING: &str = ", ";
 const DEFAULT_ENABLE_ALBUM_ART: bool = true;
 const DEFAULT_ALBUM_ART_DEADLINE: u32 = 1000;
 const DEFAULT_COMMANDS: Option<Vec<Vec<String>>> = None;
+const DEFAULT_URGENCY: u8 = 1; // Normal urgency
 
 impl Default for Configuration {
     fn default() -> Self {
@@ -76,6 +82,7 @@ impl Default for Configuration {
             enable_album_art: DEFAULT_ENABLE_ALBUM_ART,
             album_art_deadline: DEFAULT_ALBUM_ART_DEADLINE,
             commands: DEFAULT_COMMANDS,
+            urgency: DEFAULT_URGENCY,
         }
     }
 }
@@ -138,6 +145,7 @@ mod tests {
                           join_string = ' ⬥ '
                           enable_album_art = true
                           album_art_deadline = 1500
+                          urgency = 0
                           commands = [['pkill', '-RTMIN+2', 'waybar'], ['~/script.sh']]"#;
         let expected = Configuration {
             subject_format: "{track}".to_string(),
@@ -153,6 +161,7 @@ mod tests {
                 ],
                 vec!["~/script.sh".to_string()],
             ]),
+            urgency: 0,
         };
         fs::create_dir_all(&*TEST_TEMP_DIR).expect("test setup failed");
         fs::write(&conf_path, conf_data).expect("test setup failed");

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -62,14 +62,14 @@ pub struct Configuration {
     /// The urgency of the notification: 0 (low), 1 (normal), or 2 (critical).
     ///
     /// Default: [DEFAULT_URGENCY]
-    pub urgency: u8,
+    pub urgency: Option<u8>,
 
     /// The category (type) of the notification.
     /// See https://specifications.freedesktop.org/notification-spec/latest/ar01s06.html
     /// for standard categories
     ///
     /// Default: [DEFAULT_CATEGORY]
-    pub category: String,
+    pub category: Option<String>,
 }
 
 const DEFAULT_SUBJECT_FORMAT: &str = "{track}";
@@ -78,8 +78,8 @@ const DEFAULT_JOIN_STRING: &str = ", ";
 const DEFAULT_ENABLE_ALBUM_ART: bool = true;
 const DEFAULT_ALBUM_ART_DEADLINE: u32 = 1000;
 const DEFAULT_COMMANDS: Option<Vec<Vec<String>>> = None;
-const DEFAULT_URGENCY: u8 = 1; // Normal urgency
-const DEFAULT_CATEGORY: &str = "mpris.player_status";
+const DEFAULT_URGENCY: Option<u8> = Some(1); // Normal urgency
+const DEFAULT_CATEGORY: Option<String> = None;
 
 impl Default for Configuration {
     fn default() -> Self {
@@ -91,7 +91,7 @@ impl Default for Configuration {
             album_art_deadline: DEFAULT_ALBUM_ART_DEADLINE,
             commands: DEFAULT_COMMANDS,
             urgency: DEFAULT_URGENCY,
-            category: DEFAULT_CATEGORY.to_string(),
+            category: DEFAULT_CATEGORY,
         }
     }
 }
@@ -155,7 +155,7 @@ mod tests {
                           enable_album_art = true
                           album_art_deadline = 1500
                           urgency = 0
-                          category = 'mpris.changed'
+                          category = 'mpris.player_status'
                           commands = [['pkill', '-RTMIN+2', 'waybar'], ['~/script.sh']]"#;
         let expected = Configuration {
             subject_format: "{track}".to_string(),
@@ -171,8 +171,8 @@ mod tests {
                 ],
                 vec!["~/script.sh".to_string()],
             ]),
-            urgency: 0,
-            category: "mpris.changed".to_string(),
+            urgency: Some(0),
+            category: Some("mpris.player_status".to_string()),
         };
         fs::create_dir_all(&*TEST_TEMP_DIR).expect("test setup failed");
         fs::write(&conf_path, conf_data).expect("test setup failed");

--- a/src/notifier.rs
+++ b/src/notifier.rs
@@ -57,7 +57,7 @@ impl Notification {
 }
 
 type NotificationHintMap = HashMap<String, NotificationHintVariant>;
-dbus_variant_sig!(NotificationHintVariant, CaseString => String; CaseNotificationImage => NotificationImage);
+dbus_variant_sig!(NotificationHintVariant, CaseString => String; CaseNotificationImage => NotificationImage; Urgency => u8);
 
 // See: https://specifications.freedesktop.org/notification-spec/notification-spec-latest.html#icons-and-images
 #[derive(Marshal, Unmarshal, Signature, Debug, Eq, PartialEq, Clone)]
@@ -137,6 +137,10 @@ impl Notifier {
                 NotificationHintVariant::CaseNotificationImage(album_art),
             );
         }
+        hints.insert(
+            "urgency".to_string(),
+            NotificationHintVariant::Urgency(self.configuration.urgency),
+        );
         message.body.push_param(&hints)?; // hints (dict of a{sv})
         message.body.push_param(-1_i32)?; // timeout
 

--- a/src/notifier.rs
+++ b/src/notifier.rs
@@ -137,14 +137,18 @@ impl Notifier {
                 NotificationHintVariant::CaseNotificationImage(album_art),
             );
         }
-        hints.insert(
-            "urgency".to_string(),
-            NotificationHintVariant::Urgency(self.configuration.urgency),
-        );
-        hints.insert(
-            "category".to_string(),
-            NotificationHintVariant::Category(self.configuration.category.clone()),
-        );
+        if let Some(urgency) = self.configuration.urgency {
+            hints.insert(
+                "urgency".to_string(),
+                NotificationHintVariant::Urgency(urgency),
+            );
+        }
+        if let Some(category) = &self.configuration.category {
+            hints.insert(
+                "category".to_string(),
+                NotificationHintVariant::Category(category.clone()),
+            );
+        }
         message.body.push_param(&hints)?; // hints (dict of a{sv})
         message.body.push_param(-1_i32)?; // timeout
 

--- a/src/notifier.rs
+++ b/src/notifier.rs
@@ -57,7 +57,7 @@ impl Notification {
 }
 
 type NotificationHintMap = HashMap<String, NotificationHintVariant>;
-dbus_variant_sig!(NotificationHintVariant, CaseString => String; CaseNotificationImage => NotificationImage; Urgency => u8);
+dbus_variant_sig!(NotificationHintVariant, CaseString => String; CaseNotificationImage => NotificationImage; Urgency => u8; Category => String);
 
 // See: https://specifications.freedesktop.org/notification-spec/notification-spec-latest.html#icons-and-images
 #[derive(Marshal, Unmarshal, Signature, Debug, Eq, PartialEq, Clone)]
@@ -140,6 +140,10 @@ impl Notifier {
         hints.insert(
             "urgency".to_string(),
             NotificationHintVariant::Urgency(self.configuration.urgency),
+        );
+        hints.insert(
+            "category".to_string(),
+            NotificationHintVariant::Category(self.configuration.category.clone()),
         );
         message.body.push_param(&hints)?; // hints (dict of a{sv})
         message.body.push_param(-1_i32)?; // timeout


### PR DESCRIPTION
This adds support for setting the urgency and category notification hints.

https://specifications.freedesktop.org/notification-spec/notification-spec-latest.html#urgency-levels

This allows granular filtering of notifications. For instance, I usually mute low priority notifications whilst working to avoid distractions.