### PR TITLE
set the icon parameter when sending notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Configuration keys are as follows:
 * `enable_album_art`: Enable album artwork fetch. When enabled, album artwork will appear alongside the album art, provided that the art fetch completes within the deadline.
 * `album_art_deadline`: The deadline, in milliseconds, before which the album art fetch must complete, else the notification will be sent without artwork.
 * `commands`: An optional list of commands that will be run when a notification is generated. Commands must be given as a list of command sequences, where the first item is the program, and the following items are the arguments (for example, `[['~/script.sh', '--my-argument']]`).
+* `player_allowlist`: An optional list of player name substrings. When set, only players whose MPRIS well-known name (e.g., `org.mpris.MediaPlayer2.spotifyd`) contains one of the listed strings will generate notifications. For example, `player_allowlist = ['spotifyd', 'mpd']` will only show notifications from Spotifyd and MPD. When omitted, all players are allowed.
 
 The following specifiers are available for `subject_format` and `body_format`:
 

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -70,6 +70,15 @@ pub struct Configuration {
     ///
     /// Default: [DEFAULT_CATEGORY]
     pub category: Option<String>,
+
+    /// An optional list of player names to allowlist. When set, only players
+    /// whose D-Bus sender name contains an entry in this list will generate
+    /// notifications. Player names are matched as substrings of the D-Bus
+    /// well-known name (e.g., `"spotifyd"` matches
+    /// `"org.mpris.MediaPlayer2.spotifyd"`).
+    ///
+    /// Default: [DEFAULT_PLAYER_ALLOWLIST] (all players allowed)
+    pub player_allowlist: Option<Vec<String>>,
 }
 
 const DEFAULT_SUBJECT_FORMAT: &str = "{track}";
@@ -80,6 +89,7 @@ const DEFAULT_ALBUM_ART_DEADLINE: u32 = 1000;
 const DEFAULT_COMMANDS: Option<Vec<Vec<String>>> = None;
 const DEFAULT_URGENCY: Option<u8> = Some(1); // Normal urgency
 const DEFAULT_CATEGORY: Option<String> = None;
+const DEFAULT_PLAYER_ALLOWLIST: Option<Vec<String>> = None;
 
 impl Default for Configuration {
     fn default() -> Self {
@@ -92,6 +102,7 @@ impl Default for Configuration {
             commands: DEFAULT_COMMANDS,
             urgency: DEFAULT_URGENCY,
             category: DEFAULT_CATEGORY,
+            player_allowlist: DEFAULT_PLAYER_ALLOWLIST,
         }
     }
 }

--- a/src/dbus.rs
+++ b/src/dbus.rs
@@ -99,4 +99,76 @@ impl DBusConnection {
             .send_message_write_all(&add_match(&match_str))?;
         Ok(())
     }
+
+    pub fn get_initial_mpris_players(
+        &mut self,
+    ) -> Result<std::collections::HashMap<String, String>, DBusError> {
+        use rustbus::message_builder::MessageBuilder;
+        let list_msg = MessageBuilder::new()
+            .call("ListNames")
+            .with_interface("org.freedesktop.DBus")
+            .on("/org/freedesktop/DBus")
+            .at("org.freedesktop.DBus")
+            .build();
+
+        let list_serial = self
+            .connection
+            .send
+            .send_message_write_all(&list_msg)
+            .map_err(DBusError::Connection)?;
+
+        let names: Vec<String> = loop {
+            let reply = self
+                .connection
+                .recv
+                .get_next_message(rustbus::connection::Timeout::Infinite)
+                .map_err(DBusError::Connection)?;
+            if reply.typ == rustbus::MessageType::Reply
+                && reply.dynheader.response_serial == Some(list_serial)
+            {
+                let mut parser = reply.body.parser();
+                let arr: Vec<&str> = parser.get()?;
+                break arr
+                    .into_iter()
+                    .filter(|n| n.starts_with("org.mpris.MediaPlayer2."))
+                    .map(String::from)
+                    .collect();
+            }
+        };
+
+        let mut map = std::collections::HashMap::new();
+        for name in names {
+            let mut get_msg = MessageBuilder::new()
+                .call("GetNameOwner")
+                .with_interface("org.freedesktop.DBus")
+                .on("/org/freedesktop/DBus")
+                .at("org.freedesktop.DBus")
+                .build();
+            get_msg.body.push_param(&name).map_err(DBusError::Marshal)?;
+            let get_serial = self
+                .connection
+                .send
+                .send_message_write_all(&get_msg)
+                .map_err(DBusError::Connection)?;
+
+            loop {
+                let reply = self
+                    .connection
+                    .recv
+                    .get_next_message(rustbus::connection::Timeout::Infinite)
+                    .map_err(DBusError::Connection)?;
+                if reply.typ == rustbus::MessageType::Reply
+                    && reply.dynheader.response_serial == Some(get_serial)
+                {
+                    let mut parser = reply.body.parser();
+                    if let Ok(unique_name) = parser.get::<&str>() {
+                        map.insert(unique_name.to_string(), name.clone());
+                    }
+                    break;
+                }
+            }
+        }
+
+        Ok(map)
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,6 +78,13 @@ fn message_thread(
 ) -> Result<(), AppError> {
     let mut dbus = DBusConnection::new()?;
 
+    // Fetch already-running MPRIS players and their well-known names.
+    if let Ok(initial_players) = dbus.get_initial_mpris_players() {
+        message_handler.load_initial_players(initial_players);
+    } else {
+        log::warn!("Failed to fetch initial MPRIS players from D-Bus");
+    }
+
     loop {
         // Wait indefinitely for a DBus message.
         let mut message = dbus_rx.recv()?;
@@ -112,7 +119,11 @@ fn message_thread(
 }
 
 fn main() -> Result<(), AppError> {
-    simple_logger::init_with_level(log::Level::Info).unwrap();
+    simple_logger::SimpleLogger::new()
+        .with_level(log::LevelFilter::Info)
+        .env()
+        .init()
+        .unwrap();
     let configuration = load_configuration()?;
     let message_handler = MessageHandler::new(&configuration);
     let (dbus_tx, dbus_rx) = crossbeam_channel::unbounded();

--- a/src/message_handler.rs
+++ b/src/message_handler.rs
@@ -31,6 +31,10 @@ pub struct MessageHandler {
 
     // Notification that will be sent after [DEBOUNCE_PERIOD] passes.
     pending_notification: Option<Notification>,
+
+    // Map from unique D-Bus name (":1.N") -> well-known MPRIS name
+    // ("org.mpris.MediaPlayer2.<player>"). Used for allowlist matching.
+    name_map: HashMap<String, String>,
 }
 
 impl MessageHandler {
@@ -42,6 +46,13 @@ impl MessageHandler {
             metadata: HashMap::new(),
             pending_notification: None,
             status: HashMap::new(),
+            name_map: HashMap::new(),
+        }
+    }
+
+    pub fn load_initial_players(&mut self, map: HashMap<String, String>) {
+        for (unique, well_known) in map {
+            self.name_map.insert(unique, well_known);
         }
     }
 
@@ -91,19 +102,32 @@ impl MessageHandler {
         }
     }
 
-    // Called from the main loop for every received message. Sets the pending
-    // notification, but does not emit the notification; use [handle_pending]
-    // to send the notification.
+    // Called from the main loop for every received message. Handles
+    // NameOwnerChanged signals to maintain the unique→well-known name map,
+    // and sets the pending notification for MPRIS property changes.
+    // Does not emit the notification; use [fire_pending] to send it.
     pub fn process_message(
         &mut self,
         message: MarshalledMessage,
     ) -> Result<(), MessageHandlerError> {
+        // Track NameOwnerChanged to build unique-name -> well-known-name map.
+        if message
+            .dynheader
+            .member
+            .as_deref()
+            .is_some_and(|m| m == "NameOwnerChanged")
+        {
+            self.handle_name_owner_changed(&message);
+            return Ok(());
+        }
+
         let sender = message
             .dynheader
             .sender
             .as_ref()
             .ok_or_else(|| DBusError::Invalid("Missing sender header".to_string()))?
             .clone();
+
         let change = MprisPropertiesChange::try_from(message).ok();
 
         // Signals we don't care about are ignored
@@ -111,6 +135,23 @@ impl MessageHandler {
             return Ok(());
         }
         let change = change.unwrap();
+
+        // Apply allowlist if configured: check if this sender's well-known
+        // name contains any of the allowlisted player name substrings.
+        if let Some(allowlist) = &self.configuration.player_allowlist {
+            let well_known = self.name_map.get(&sender).map(String::as_str).unwrap_or("unknown");
+            let allowed = allowlist
+                .iter()
+                .any(|entry| well_known.contains(entry.as_str()));
+            if !allowed {
+                log::debug!(
+                    "Ignoring signal from '{}' (well-known: '{}'), not in allowlist",
+                    sender,
+                    well_known
+                );
+                return Ok(());
+            }
+        }
 
         // Handle metadata property changes.
         //
@@ -201,5 +242,42 @@ impl MessageHandler {
         }
 
         Ok(())
+    }
+
+    // Handles a NameOwnerChanged signal from org.freedesktop.DBus to maintain
+    // the unique-name -> well-known-name map used for allowlist matching.
+    // The signal body is (name: &str, old_owner: &str, new_owner: &str):
+    //   - new_owner non-empty: a service acquired the name
+    //   - new_owner empty: a service released the name
+    fn handle_name_owner_changed(&mut self, message: &MarshalledMessage) {
+        let mut parser = message.body.parser();
+        let name = match parser.get::<&str>() {
+            Ok(s) => s,
+            Err(_) => return,
+        };
+        let _old_owner = match parser.get::<&str>() {
+            Ok(s) => s,
+            Err(_) => return,
+        };
+        let new_owner = match parser.get::<&str>() {
+            Ok(s) => s,
+            Err(_) => return,
+        };
+
+        // NameOwnerChanged fires for every D-Bus service, not just MPRIS players.
+        // Skip non-MPRIS names to avoid accumulating irrelevant entries in name_map.
+        if !name.starts_with("org.mpris.MediaPlayer2.") {
+            return;
+        }
+
+        if new_owner.is_empty() {
+            // Player unregistered: remove from map by value.
+            self.name_map.retain(|_, v| v != name);
+            log::debug!("MPRIS player unregistered: {}", name);
+        } else {
+            // Player registered: map unique name -> well-known name.
+            self.name_map.insert(new_owner.to_string(), name.to_string());
+            log::debug!("MPRIS player registered: {} -> {}", new_owner, name);
+        }
     }
 }

--- a/src/mpris.rs
+++ b/src/mpris.rs
@@ -99,5 +99,13 @@ pub fn subscribe_mpris(dbus: &mut DBusConnection) -> Result<(), DBusError> {
         MPRIS_SIGNAL_INTERFACE,
         MPRIS_SIGNAL_MEMBER,
         MPRIS_SIGNAL_OBJECT,
-    )
+    )?;
+    subscribe_name_owner_changed(dbus)
+}
+
+// Subscribe to NameOwnerChanged signals from org.freedesktop.DBus so that
+// the message handler can maintain a unique-name -> well-known-name map,
+// enabling allowlist matching by friendly player name.
+fn subscribe_name_owner_changed(dbus: &mut DBusConnection) -> Result<(), DBusError> {
+    dbus.subscribe("org.freedesktop.DBus", "NameOwnerChanged", "/org/freedesktop/DBus")
 }

--- a/src/notifier.rs
+++ b/src/notifier.rs
@@ -112,9 +112,16 @@ impl Notifier {
             return Ok(());
         }
 
+        // dunst's stack_tag icon merge used by x-canonical-private-synchronous below only
+        // refreshes the notification icon when this field changes between the old and new
+        // notification. Keep it unique per notification to avoid the previous notification's icon
+        // getting stuck when a new track is played while a notification is active, e.g. when
+        // skipping tracks back-to-back.
+        let icon = metadata.track_id.as_deref().unwrap_or("");
+
         message.body.push_param(NOTIFICATION_SOURCE)?; // appname (TODO)
         message.body.push_param(0_u32)?; // update ID
-        message.body.push_param("")?; // icon
+        message.body.push_param(icon)?; // icon
         message.body.push_param(subject)?; // summary
         message.body.push_param(body)?; // body
         message.body.push_param(Vec::<String>::new())?; // actions (array of strings)


### PR DESCRIPTION
When dunst is the notification daemon in use and there's already an active notification, skipping to
a new track replaces subject and body of the active notification, as requested by the
`x-canonical-private-synchronous` hint. However, the icon stays unchanged as no `icon` parameter is
being set.

To avoid this, set the `icon` parameter based on the current track ID.

Verified by running `mpris-notifier` with the changes and rapidly skipping tracks. With this change,
the active notification subjent and body is replaced, and the icon is updated as well.
